### PR TITLE
fix application crash due to mission resource string

### DIFF
--- a/src/android/src/gmvScanner/BarcodeCaptureActivity.java
+++ b/src/android/src/gmvScanner/BarcodeCaptureActivity.java
@@ -339,9 +339,9 @@ public final class BarcodeCaptureActivity extends AppCompatActivity implements B
         };
 
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setTitle("Multitracker sample")
+        builder.setTitle("Camera permission required")
                 .setMessage(getResources().getIdentifier("no_camera_permission", "string", getPackageName()))
-                .setPositiveButton(getResources().getIdentifier("listener", "string", getPackageName()), listener)
+                .setPositiveButton(getResources().getIdentifier("ok", "string", getPackageName()), listener)
                 .show();
     }
 


### PR DESCRIPTION
Fix application crash due to mission resource string and update dialog title in permission not granted case

Reference:
![2018-08-13 16 58 03](https://user-images.githubusercontent.com/15091860/44036432-71d14182-9f1a-11e8-9130-10d17956661e.png)
![2018-08-13 17 00 17](https://user-images.githubusercontent.com/15091860/44036433-71eef3da-9f1a-11e8-9947-8ad39d08413c.png)
