### PR TITLE
Fix plugin's crash when Activity gets destroyed by OS, rename activity_main.xml to prevent possible errors

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -109,7 +109,7 @@
                      target-dir="src/com/dealrinc/gmvScanner/ui/camera"/>
 
         <resource-file src="src/android/res/layout/activity_main.xml"
-                       target="res/layout/activity_main.xml"/>
+                       target="res/layout/activity_gmv_barcode_scanner.xml"/>
         <resource-file src="src/android/res/layout/barcode_capture.xml"
                        target="res/layout/barcode_capture.xml"/>
 

--- a/src/android/src/gmvScanner/CDVAndroidScanner.java
+++ b/src/android/src/gmvScanner/CDVAndroidScanner.java
@@ -11,6 +11,7 @@ import org.json.JSONException;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.util.Log;
 import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.vision.barcode.Barcode;
@@ -65,6 +66,8 @@ public class CDVAndroidScanner extends CordovaPlugin {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        
         if (requestCode == RC_BARCODE_CAPTURE) {
             if (resultCode == CommonStatusCodes.SUCCESS) {
                 Intent d = new Intent();
@@ -87,10 +90,13 @@ public class CDVAndroidScanner extends CordovaPlugin {
                 mCallbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, result));
             }
         }
-        else {
-            super.onActivityResult(requestCode, resultCode, data);
-        }
     }
+    
+    @Override
+    public void onRestoreStateForActivityResult(Bundle state, CallbackContext callbackContext) {
+        mCallbackContext = callbackContext;
+    }
+    
 /*
     private void startScan(CallbackContext callbackContext) {
 		Intent intent = new Intent(this, MainActivity.class);

--- a/src/android/src/gmvScanner/SecondaryActivity.java
+++ b/src/android/src/gmvScanner/SecondaryActivity.java
@@ -46,7 +46,7 @@ public class SecondaryActivity extends Activity implements View.OnClickListener 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(getResources().getIdentifier("activity_main", "layout", getPackageName()));
+        setContentView(getResources().getIdentifier("activity_gmv_barcode_scanner", "layout", getPackageName()));
 
         findViewById(getResources().getIdentifier("read_barcode", "id", getPackageName())).setOnClickListener(this);
 


### PR DESCRIPTION
Hi! Found another couple of Android bugs.

1. It is better to have a distinct name for the plugin's activity layout. When two or more cordova plugins save their activity layout under the same name (for example classic **activity_main.xml** filename) they overwrite each other's layouts when android platform is being added and at least one of them stops working as a result. 

2. Also, the plugin crashes when it's Activity gets destroyed by the OS (due to lack of RAM on the device). This commit should fix both bugs.