### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@
         <framework src="Foundation.framework"/>
         <framework src="AVFoundation.framework"/>
         <framework src="UIKit.framework"/>
-        <framework spec="~&gt; 1.1" src="GoogleMobileVision/BarcodeDetector" type="podspec"/>
+        <framework spec="=1.1" src="GoogleMobileVision/BarcodeDetector" type="podspec"/>
         <header-file src="src/ios/CDViOSScanner.h"/>
         <source-file src="src/ios/CDViOSScanner.m"/>
         <header-file src="src/ios/CameraViewController.h"/>


### PR DESCRIPTION
Later versions, namely 1.6, of GMV have the `UIWebView` component, which leads to rejection from the Apple App Store because it's deprecated. Also, my latest info is that GMV will not fix this, as they moved the GMV to the ML kit. Maybe later versions <1.6 will work, too, I don't know at what version `UIWebView` was introduced.

To fix the `UIWebView` issue, we just make the GMV version lock to 1.1.